### PR TITLE
Beautify events page

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,19 +1,31 @@
-<ul class="event-list container">
-  <% @events.each do |e| %>
-    <div class="row event-row">
-      <h4 class="col-md-4"><%= e.title %></h4>
-      <h4 class="col-md-4"> <%= e.date %></h4>
+<div class="container">
+  <h1>Events</h1>
 
-      <div class="col-md-1 col-md-offset-2">
-        <%= link_to "Edit", edit_event_path(e), class: 'btn btn-warning edit_event' %>
-      </div>
+  <button type="button" class="btn btn-default"><span class='glyphicon glyphicon-plus' aria-hidden='true'></span> Add New Event</button>
+  <br><br>
 
-      <div class="col-md-1">
-        <%= link_to "Delete", e, :method => :delete, class: 'btn btn-danger delete_event', remote: true, data: { confirm: "Are you sure you want to delete this event?" } %>
-      </div>
-
-      <div class="col-md-12"><%= e.description %></div>
-
-    </div>
-  <% end %>
-</ul>
+  <div class="table-responsive">
+	<table class="event-list table table-condensed">
+	    <tr>
+		<th>Date</th>
+		<th>Title</th>
+		<th>Description</th>
+		<th>Edit</th>
+		<th>Delete</th>
+	    </tr>
+	  <% @events.each do |e| %>
+	    <tr>
+	      <td> <%= e.date %></td>
+	      <td><%= e.title %></td>
+	      <td><%= e.description %></td>
+	      <td>
+		<%= link_to raw("<span class='glyphicon glyphicon-pencil' aria-hidden='true'></span>"), edit_event_path(e), class: 'btn btn-warning edit_event' %>
+	      </td>
+	      <td>
+		<%= link_to(raw("<span class='glyphicon glyphicon-trash' aria-hidden='true'></span>"), e, :method => :delete, class: 'btn btn-danger delete_event', remote: true, data: { confirm: "Are you sure you want to delete this event?" }) %>
+	      </td>
+	    </tr>
+	  <% end %>
+	</table>
+  </div>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <h1>Events</h1>
 
-  <button type="button" class="btn btn-default"><span class='glyphicon glyphicon-plus' aria-hidden='true'></span> Add New Event</button>
+  <button type="button" class="btn btn-default btn-primary"><span class='glyphicon glyphicon-plus' aria-hidden='true'></span> Add New Event</button>
   <br><br>
 
   <div class="table-responsive">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <h1>Events</h1>
 
-  <button type="button" class="btn btn-default btn-primary"><span class='glyphicon glyphicon-plus' aria-hidden='true'></span> Add New Event</button>
+  <%= link_to raw("<span class='glyphicon glyphicon-plus' aria-hidden='true'></span> Add New Event"), new_event_path, class: 'btn btn-default btn-primary new_event' %>
   <br><br>
 
   <div class="table-responsive">


### PR DESCRIPTION
This commit does the following:
- Adds a "Create New" button on the Events index page, so we can actually access that route
- Improves styling in general on the events page
- Uses beautiful glyphicons to the buttons 
