### PR TITLE
Submission-related admin views

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -1,0 +1,50 @@
+class ApplicantsController < ApplicationController
+
+  respond_to :html, :json
+
+  before_action :find_applicant, only: [:edit, :index, :update, :destroy]
+
+  def index
+    @applicants = Applicant.order("LOWER(last_name), LOWER(first_name)")
+  end
+
+  def edit
+  end
+
+  def update
+    @applicant = Applicant.find(params[:id]) if params[:id]
+    @applicant.update(applicant_params)
+    redirect_to applicants_path
+  end
+
+  def destroy
+      @applicant.destroy
+      respond_to do |format|
+        format.html { redirect_to applicants_path,
+                      notice: "Your action completed successfully." }
+        format.json { head :no_content }
+      end
+  end
+
+  private
+  def find_applicant
+    @applicant = Applicant.find(params[:id]) if params[:id]
+  end
+
+
+  def applicant_params
+    params.require(:applicant).permit(:address_1,
+                                      :address_2,
+                                      :city,
+                                      :email_address,
+                                      :first_name,
+                                      :home_telephone_number,
+                                      :last_name,
+                                      :mobile_telephone_number,
+                                      :state,
+                                      :under_18,
+                                      :work_telephone_number,
+                                      :zip_code,
+    )
+  end
+end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,0 +1,57 @@
+class QuestionsController < ApplicationController
+
+  respond_to :html, :json
+
+  before_action :find_question, only: [:index, :update, :destroy]
+
+  def index
+    @questions = Question.order(:position, :name)
+    @input_types_array = ["checkbox",
+                          "date",
+                          "datetime",
+                          "info_text",
+                          "integer",
+                          "multiselect",
+                          "radio",
+                          "select",
+                          "string",
+                          "text",
+                          "textarea"]
+  end
+
+  def update
+    @question = Question.find(params[:id]) if params[:id]
+    @question.update(question_params)
+    respond_with @question
+  end
+
+  def destroy
+      @question.destroy
+      respond_to do |format|
+        format.html { redirect_to questions_path,
+                      notice: "Your action completed successfully." }
+        format.json { head :no_content }
+      end
+  end
+
+  private
+  def find_question
+    @question = Question.find(params[:id]) if params[:id]
+  end
+
+
+  def question_params
+    params.require(:question).permit(:active,
+                                     :admin_only_question,
+                                     :answer_type,
+                                     :hint_text,
+                                     :input_type,
+                                     :is_required,
+                                     :name,
+                                     :option_list,
+                                     :parent_id,
+                                     :position,
+                                     :short_name,
+    )
+  end
+end

--- a/app/controllers/submission_template_questions_controller.rb
+++ b/app/controllers/submission_template_questions_controller.rb
@@ -1,0 +1,44 @@
+class SubmissionTemplateQuestionsController < ApplicationController
+
+  respond_to :html, :json
+
+  before_action :find_submission_template_question, only: [:index, :update, :destroy]
+
+  def index
+    @submission_template_questions = SubmissionTemplateQuestion.
+        includes({ :submission_template => :pet_type }, :question).
+        order("pet_types.id, submission_templates.id, questions.position, questions.name")
+
+    @submission_templates_array = SubmissionTemplate.all.map{ |st| [st.id, st.name] }
+    @questions_array = Question.all.map{ |q| [q.id,  q.name.truncate(75) + " (" + q.position.to_s + ")"] }
+  end
+
+  def update
+    @submission_template_question.update(submission_template_question_params)
+    respond_with @submission_template_question
+  end
+
+  def destroy
+    @submission_template_question.destroy
+    respond_to do |format|
+      format.html { redirect_to questions_path, notice: "Your action completed successfully." }
+      format.json { head :no_content }
+    end
+  end
+
+
+  private
+  def find_submission_template_question
+    if params && params[:id]
+      @submission_template_question = SubmissionTemplateQuestion.find(params[:id])
+    else
+      @submission_template_question = SubmissionTemplateQuestion.new
+    end
+
+  end
+
+  def submission_template_question_params
+    params.require(:submission_template_question).permit(:question_id,
+                                                         :submission_template_id)
+  end
+end

--- a/app/controllers/submission_templates_controller.rb
+++ b/app/controllers/submission_templates_controller.rb
@@ -1,0 +1,23 @@
+class SubmissionTemplatesController < ApplicationController
+
+  respond_to :html, :json
+
+  def index
+    @submission_templates = SubmissionTemplate.includes(:pet_type).order("submission_templates.id desc")
+  end
+
+  def update
+    @submission_template = SubmissionTemplate.find(params[:id]) if params[:id]
+    @submission_template.update(submission_template_params)
+    respond_with @submission_template
+  end
+
+
+  private
+  def submission_template_params
+    params.require(:submission_template).permit(:name,
+                                                :pet_type_id,
+                                                :submission_thank_you_text,
+    )
+  end
+end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,23 +1,115 @@
+require "#{Rails.root}/app/helpers/application_helper.rb"
+include ApplicationHelper
+
 class SubmissionsController < ApplicationController
-  # TODO add the 'rest' of the controller actions
   # TODO add the logic for admin_only questions in the form
 
+  respond_to :html, :json
+
+  def index
+    @submissions = Submission.includes(:applicant,
+                                       {responses: :question},
+                                       :submission_template).
+                                        references(:applicant,
+                                                   :questions,
+                                                   :responses).
+                                        order("submissions.id desc,
+                                               questions.position,
+                                               responses.id")
+    @answered_question_names_array = Question.answered_question_names if Question.any?
+  end
+
   def new
-    @submission = Submission.new_with_responses( params[:form_type_id] )
+    @submission = Submission.new_with_responses(params[""])
+    @submission.applicant.build
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def create
     @submission = Submission.new(submission_params)
-    if @submission.save
-      redirect_to root_path
-    else
-      render :new
+
+    respond_to do |format|
+      if @submission.save
+        format.html { redirect_to submissions_path,
+                                  notice: 'Submission successfully created.' }
+        format.json { render :new,
+                             status: :created,
+                             location: @submission }
+      else
+        format.html { render :new }
+        format.json { render json: @submission.errors,
+                             status: :unprocessable_entity }
+      end
     end
   end
 
+  def edit
+    @submission = Submission.find(params[:id]) if params[:id]
+    @applicant = @submission.applicant
+
+    @parent_questions = Question.where(id: Question.pluck(:parent_id).uniq)
+  end
+
+  def update
+    @submission = Submission.find(params[:id]) if params[:id]
+    @submission.update(submission_params)
+    respond_with @submission
+  end
+
+  def show
+    set_submission_template_variables
+    @applicant = @submission.applicant if @submission
+  end
+
+  private def find_submission
+    @submission = Submission.
+        includes(submission_template: :pet_type).
+        find(params[:id]) if params[:id]
+  end
+
+  private def set_submission_template_headers
+    @submissions = Submission.includes({responses: :question}).
+      references(:responses, :questions).
+      order("submissions.id desc, questions.position, responses.id")
+    @submission_template_headers =
+      @submissions.last.submission_template.questions.
+                                            order("questions.position").
+                                            pluck(:name, :short_name)
+  end
+
+  private def set_submission_template_variables
+    find_submission
+    if @submission
+      @submission_template = @submission.submission_template
+    else
+      @submission_template = SubmissionTemplate.first
+    end
+    @submission_template_form_name = @submission_template.name
+    @submission_template_pet_type_name = @submission_template.pet_type.name
+  end
 
   private def submission_params
-    # FIXME add 'response attributes'
-    params.require(:submission).permit! # (:date, :title, :description)
+    params.require(:submission).(:applicant_id,
+                                 :submission_template_id,
+                                 { responses_attributes:
+                                     [ :id,
+                                       :applicant_id,
+                                       { :array_response => [] },
+                                       :boolean_response,
+                                       :date_response,
+                                       :datetime_response,
+                                       :integer_response,
+                                       :question_id,
+                                       :string_response,
+                                       :submission_id,
+                                       :text_response,
+                                       :created_at,
+                                       :updated_at,
+                                       :_destroy ]
+                                 },
+    )
   end
 end

--- a/app/views/applicants/_index.html.erb
+++ b/app/views/applicants/_index.html.erb
@@ -1,0 +1,58 @@
+<div class="col-md-12">
+  <table class="table table-bordered table-condensed table-hover
+                table-responsive table-striped table-white-background
+                ">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Last Name</th>
+        <th>First Name</th>
+        <th>Email</th>
+        <th>Home Phone</th>
+        <th>Work Phone</th>
+        <th>Cell Phone</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @applicants.each do |applicant| %>
+        <tr data-object="submission_template_question">
+          <td><%= link_to(applicant.id, edit_applicant_path(applicant.id)) %></td>
+          <td><%= best_in_place(applicant,
+                                :last_name,
+                                as: :input,
+                                :place_holder => "---") %></td>
+          <td><%= best_in_place(applicant,
+                                :first_name,
+                                as: :input,
+                                :place_holder => "---") %></td>
+          <td><%= best_in_place(applicant,
+                                :email_address,
+                                as: :input,
+                                :place_holder => "---") %></td>
+          <td><%= best_in_place(applicant,
+                                :home_telephone_number,
+                                as: :input,
+                                :place_holder => "---") %></td>
+          <td><%= best_in_place(applicant,
+                                :work_telephone_number,
+                                as: :input,
+                                :place_holder => "---") %></td>
+          <td><%= best_in_place(applicant,
+                                :mobile_telephone_number,
+                                as: :input,
+                                :place_holder => "---") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<script>
+    $(document).ready(function() {
+        /* Activating Best In Place */
+        jQuery(".best_in_place").best_in_place();
+    });
+
+    $('.best_in_place').bind("ajax:success", function () {$(this).closest('tr').effect('highlight'); });
+</script>

--- a/app/views/applicants/edit.html.erb
+++ b/app/views/applicants/edit.html.erb
@@ -1,0 +1,16 @@
+<div>
+  <%= simple_form_for @applicant,
+                      as: 'applicant',
+                      html: { class: 'form-horizontal' } do |applicant_form| %>
+
+    <%= validation_error_prompt(@applicant) %>
+
+    <div class="applicant-fields field-section">
+      <%= render partial: "public/applicant_fields", locals: { applicant_form: applicant_form } %>
+    </div>
+
+    <div class="submit-button">
+      <%= applicant_form.button :submit, "Submit", { class: "btn btn-primary" } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "layouts/index_template" %>

--- a/app/views/questions/_index.html.erb
+++ b/app/views/questions/_index.html.erb
@@ -1,0 +1,94 @@
+<div class="col-md-12">
+  <%#= render partial: "question_fields_table" %>
+  <table class="table table-bordered table-condensed table-hover
+                table-responsive table-striped table-white-background
+                ">
+    <thead>
+      <tr>
+        <th>Admin Only?</th>
+        <th>Position</th>
+        <th>Question Short Name</th>
+        <th>Question Long Name</th>
+        <th>Input Type</th>
+        <th>Option List (format: "{Option 1,Option 2}" --> ["Option 1", "Option 2"])</th>
+        <th>Hint Text</th>
+        <th>Required Field?</th>
+        <th>ID</th>
+        <th>Parent QID</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @questions.each do |q| %>
+        <tr data-object="submission_template_question">
+  <!--#TODO - get admin_only_q to display as yes_no(q.admin_only_question)-->
+          <td><%= best_in_place(q,
+                                :admin_only_question,
+                                as: :boolean,
+                                :place_holder => "---") %></td>
+          <td><%= best_in_place(q,
+                                :position,
+                                as: :input,
+                                :place_holder => "---") %></td>
+          <td><%= best_in_place(q,
+                                :short_name,
+                                as: :input,
+                                :place_holder => "---") %></td>
+          <td><%= best_in_place(q,
+                                :name,
+                                as: :textarea,
+                                :place_holder => "---") %></td>
+          <td><%= best_in_place(q,
+                                :input_type,
+                                as: :select,
+                                collection:
+                                    @input_types_array.map{ |q| [q, q] })#,
+                                # :value => @input_types_array.
+                                #   detect{ |(_, n)| n == q.input_type},
+                                # :place_holder: "---"
+          %></td>
+          <td><%= best_in_place(q,
+                                :option_list,
+                                as: :textarea,
+                                value: q.option_list) %></td>
+          <td><%= best_in_place(q,
+                                :hint_text,
+                                as: :textarea,
+                                placeholder: "---",
+                                value: q.hint_text) %></td>
+          <td><%= best_in_place(q,
+                                :is_required,
+                                as: :select,
+                                collection: [[true, "YES"], [false, "No"]],
+                                placeholder: "---",
+                                value: q.is_required) %></td>
+          <td><%= link_to(q.id.to_s, q, method: :delete,
+                    data: { confirm: 'Are you sure you want to DELETE
+                      this and all associated records?' },
+                    remote: true, style: "color:
+           black; text-decoration: none;") %></td>
+          <td><%= best_in_place(q,
+                                :parent_id,
+                                as: :input,
+                                :place_holder => "---")
+
+              %>
+              <%= (" (" + (q.parent.short_name + " - position: " +
+                             q.parent.position.to_s || "") +
+                       ")") if q.parent
+              %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<script>
+    $(document).ready(function() {
+        /* Activating Best In Place */
+        jQuery(".best_in_place").best_in_place();
+    });
+
+    $('.best_in_place').bind("ajax:success", function () {$(this).closest('tr').effect('highlight'); });
+</script>

--- a/app/views/questions/_question_fields_table.html.erb
+++ b/app/views/questions/_question_fields_table.html.erb
@@ -1,0 +1,57 @@
+<fieldset>
+  <% unless /---/.match(Question.last.name) && /---/.match(Question.last.name).size > 0 %>
+    <table class="table table-bordered table-condensed table-hover
+                  table-responsive table-striped table-new-record
+                  ">
+      <thead>
+      <tr>
+        <th>Position</th>
+        <th>Question Short Name</th>
+        <th>Question Long Name</th>
+        <th>Input Type</th>
+        <th>Option List</th>
+        <th>Hint Text</th>
+        <th>Required Field?</th>
+        <th>ID</th>
+        <th>Parent QID</th>
+      </tr>
+      </thead>
+
+      <tbody>
+        <% Question.all.create(name: "---#{ Question.last.id }", input_type: "string") do |q| %>
+            <tr data-object="submission_template_question">
+              <td><%= best_in_place(q, :position,
+                                    as: :input,
+                                    :place_holder => "---") %></td>
+              <td><%= best_in_place(q,
+                                    :short_name,
+                                    as: :input,
+                                    :place_holder => "---") %></td>
+              <td><%= best_in_place(q, :name,
+                                    as: :textarea,
+                                    :place_holder => "---") %></td>
+              <td><%= best_in_place(q, :input_type,
+                                    as: :select,
+                                    value: @input_types_array.detect{ |(_, n)| n == q.input_type },
+                                    collection: @input_types_array.map{ |q| [q, q] }) %></td>
+              <td><%= best_in_place(q, :option_list,
+                                    as: :input,
+                                    value: q.option_list) %></td>
+              <td><%= best_in_place(q, :hint_text,
+                                    as: :textarea,
+                                    value: q.hint_text) %></td>
+              <td><%= best_in_place(q, :is_required,
+                                    as: :check_box,
+                                    value: q.is_required) %></td>
+              <td><%= link_to(q.id.to_s, q, method: :delete,
+                              data: { confirm: 'Are you sure you want to DELETE this and all associated records?' },
+                              remote: true, style: "color: black; text-decoration: none;") %></td>
+              <td><%= best_in_place(q, :parent_id,
+                                    as: :input,
+                                    :place_holder => "---") %></td>
+            </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</fieldset>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "layouts/index_template" %>

--- a/app/views/submission_template_questions/_index.html.erb
+++ b/app/views/submission_template_questions/_index.html.erb
@@ -1,0 +1,54 @@
+<div class="col-md-12">
+  <p>* Use this page to add questions to a submission template. (Other options:
+    <%= link_to "Edit Question Details", :questions %>)
+  </p>
+  <br/><br/>
+  <%= simple_fields_for :submission_template_questions do %>
+    <table class="table table-striped table-hover table-condensed table-responsive">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Pet Type</th>
+          <th>Submission Template</th>
+          <th>Question (position)</th>
+          <th>Created on</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @submission_template_questions.
+            includes(:question, { submission_template: :pet_type }).
+            order('questions.position').each do |stq| %>
+          <tr data-object="submission_template_question">
+            <td><%= stq.id %></td>
+            <td><%= stq.submission_template.pet_type.name %></td>
+            <td><%= best_in_place(stq, :submission_template_id,
+                                  as: :select,
+                                  collection: @submission_templates_array,
+                                  :place_holder => "---") %></td>
+            <td><%= best_in_place(stq, :question_id,
+                                  as: :select,
+                                  collection: @questions_array,
+                                  :place_holder => "---") %></td>
+            <td><%= link_to "#{stq.created_at.strftime("%b %d %l:%M %p")}",
+                               stq,
+                               method: :delete,
+                               data: { confirm: 'Are you sure you want to DELETE this and all associated records?' },
+                               remote: true,
+                               style: "color: black; text-decoration: none;"
+            %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</div>
+
+<script>
+    $(document).ready(function() {
+        /* Activating Best In Place */
+        jQuery(".best_in_place").best_in_place();
+    });
+
+    $('.best_in_place').bind("ajax:success", function () {$(this).closest('tr').effect('highlight'); });
+</script>

--- a/app/views/submission_template_questions/_submission_template_question_fields_table.html.erb
+++ b/app/views/submission_template_questions/_submission_template_question_fields_table.html.erb
@@ -1,0 +1,9 @@
+<fieldset>
+  <%= simple_form_for :submission_template_questions, as: "submission_template_question" do |stq| %>
+    <% unless /---/.match(SubmissionTemplate.last.name) && /---/.match(SubmissionTemplate.last.name).size > 0 %>
+          <%= stq.association :submission_template %>
+          <%= stq.association :question %>
+          <%= stq.input :id, disabled: true     %></td>
+    <% end %>
+  <% end %>
+</fieldset>

--- a/app/views/submission_template_questions/index.html.erb
+++ b/app/views/submission_template_questions/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "layouts/index_template" %>

--- a/app/views/submission_templates/_form.html.erb
+++ b/app/views/submission_templates/_form.html.erb
@@ -1,0 +1,32 @@
+<div>
+  <%= simple_form_for @submission_template,
+                      url: submission_template_path,
+                      as: 'submission_template',
+                      html: { class: 'form-horizontal' } do |submission_template| %>
+
+    <%= validation_error_prompt(@submission_template) %>
+
+    <div class="form-inline display-block">
+      <%= submission_template.input :name,
+                                    as: :string,
+                                    required: true,
+                                    input_html: { class: "form-field-display-block" },
+                                    label_html: { class: "form-field-display-block" } %>
+      <%= submission_template.input :pet_type,
+                                    as: :radio_buttons,
+                                    required: true,
+                                    collection: @pet_types,
+                                    class: "input-radio" %>
+      <%= submission_template.input :submission_thank_you_text,
+                                    as: :string,
+                                    required: true,
+                                    input_html: { class: "form-field-display-block"},
+                                    label_html: { class: "form-field-display-block" } %>
+    </div>
+
+    <div>
+      <%= submission_template.button :submit, "Submit", { class: "btn btn-primary" } %>
+    </div>
+
+  <% end %>
+</div>

--- a/app/views/submission_templates/_index.html.erb
+++ b/app/views/submission_templates/_index.html.erb
@@ -1,0 +1,24 @@
+<div class="col-md-12">
+  <table class="table table-vertical-lines table-striped table-hover
+                table-condensed table-responsive">
+    <thead style="background-color: beige">
+    <tr>
+      <td>ID</td>
+      <td>Name</td>
+      <td>Pet Type</td>
+      <td>Submission Thank You Text</td>
+    </tr>
+    </thead>
+
+    <tbody>
+      <% @submission_templates.each do |submission_template| %>
+        <tr>
+          <td><%= submission_template.id %></td>
+          <td><%= submission_template.name %></td>
+          <td><%= submission_template.pet_type.andand.name %></td>
+          <td><%= submission_template.submission_thank_you_text %></td>
+        </tr>
+      <% end%>
+    </tbody>
+  </table>
+</div>

--- a/app/views/submission_templates/index.html.erb
+++ b/app/views/submission_templates/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "layouts/index_template" %>


### PR DESCRIPTION
- still need to figure out why best-in-place isn't working! if we can get the JS set up, we won't need so many CRUD views... the "fields" views can be used at top of page for one-stop shopping on these admin index pages.
- added start of admin (CRUD) views:
- submissions index & _form
- applicants index, edit
- questions index
- submission_template index
- submission_template_questions index
